### PR TITLE
Introduce shared config and refactor constants

### DIFF
--- a/README
+++ b/README
@@ -14,6 +14,23 @@ The server requires Python 3 and the Twisted framework. Install dependencies wit
 pip install twisted requests
 ```
 
+### Configuration
+
+Runtime constants such as network ports, banned IPs and lobby names are
+defined in `config.py`. Adjust these values as needed. The default ports
+match the existing behaviour:
+
+```
+GG2_PORT = 29942
+NEWSTYLE_PORT = 29944
+WEB_PORT = 29950
+```
+
+The Munin plugins rely on `config.py` as well. When symlinked into
+`/etc/munin/plugins` make sure the plugins can locate the repository so the
+import succeeds (they add the parent directory of the real script path to
+`sys.path`).
+
 ## Running Tests
 
 The project includes comprehensive integration tests that verify all protocols and functionality:

--- a/config.py
+++ b/config.py
@@ -1,0 +1,28 @@
+import socket
+import uuid
+
+# Network ports for lobby protocols and web UI
+GG2_PORT = 29942  # Legacy GG2 registration/query
+NEWSTYLE_PORT = 29944  # New-style registration/query
+WEB_PORT = 29950  # Web status interface
+
+# Banned IP list
+BANNED_IP_STRINGS = {"1.2.3.4"}
+BANNED_IPS = {socket.inet_aton(ip) for ip in BANNED_IP_STRINGS}
+
+# Flood-control and server expiration durations
+SERVER_EXPIRATION_SECS = 70
+REGISTRATION_THROTTLE_SECS = 10
+
+# Connection timeouts (used for various protocol operations)
+CONNECTION_TIMEOUT_SECS = 5
+
+# Known lobbies and display assets for the web interface
+KNOWN_LOBBIES = {
+    uuid.UUID("1ccf16b1-436d-856f-504d-cc1af306aaa7"): "Gang Garrison Lobby",
+    uuid.UUID("0e29560e-443a-93a3-e15e-7bd072df7506"): "PyGG2 Testing Lobby",
+    uuid.UUID("4fd0319b-5868-4f24-8b77-568cbb18fde9"): "Vanguard Lobby",
+}
+
+LOGO_SMFL = "http://static.ganggarrison.com/Themes/GG2/images/smflogo.gif"
+LOGO_MAIN = "http://static.ganggarrison.com/GG2ForumLogo.png"

--- a/lobby.py
+++ b/lobby.py
@@ -1,6 +1,7 @@
 import twisted.web.server
 import twisted.web.static
 from twisted.internet import reactor
+import config
 
 from server import GameServerList
 from protocols.gg2 import GG2LobbyRegV1, GG2LobbyQueryV1Factory
@@ -8,13 +9,13 @@ from protocols.newstyle import NewStyleReg, NewStyleListFactory
 import weblist
 
 serverList = GameServerList()
-reactor.listenUDP(29942, GG2LobbyRegV1(serverList))
-reactor.listenUDP(29944, NewStyleReg(serverList))
-reactor.listenTCP(29942, GG2LobbyQueryV1Factory(serverList))
-reactor.listenTCP(29944, NewStyleListFactory(serverList))
+reactor.listenUDP(config.GG2_PORT, GG2LobbyRegV1(serverList))
+reactor.listenUDP(config.NEWSTYLE_PORT, NewStyleReg(serverList))
+reactor.listenTCP(config.GG2_PORT, GG2LobbyQueryV1Factory(serverList))
+reactor.listenTCP(config.NEWSTYLE_PORT, NewStyleListFactory(serverList))
 
 webres = twisted.web.static.File("httpdocs")
 webres.putChild(b"status", weblist.LobbyStatusResource(serverList))
 
-reactor.listenTCP(29950, twisted.web.server.Site(webres))
+reactor.listenTCP(config.WEB_PORT, twisted.web.server.Site(webres))
 reactor.run()

--- a/munin-plugins/gg2_players.py
+++ b/munin-plugins/gg2_players.py
@@ -2,7 +2,10 @@
 
 from __future__ import with_statement
 from contextlib import closing
-import socket, uuid, struct, sys
+import socket, uuid, struct, sys, os
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
+import config
 
 def read_fully(sock, length):
 	result = b''
@@ -19,7 +22,7 @@ else:
 	LIST_PROTOCOL_ID = uuid.UUID("297d0df4-430c-bf61-640a-640897eaef57")
 	GG2_LOBBY_ID = uuid.UUID("1ccf16b1-436d-856f-504d-cc1af306aaa7")
 
-	with closing(socket.create_connection(("127.0.0.1", 29944))) as sock:
+	with closing(socket.create_connection(("127.0.0.1", config.NEWSTYLE_PORT))) as sock:
 		sock.sendall(LIST_PROTOCOL_ID.bytes + GG2_LOBBY_ID.bytes)
 
 		total_playercount = 0

--- a/munin-plugins/gg2_servers.py
+++ b/munin-plugins/gg2_servers.py
@@ -2,7 +2,10 @@
 
 from __future__ import with_statement
 from contextlib import closing
-import socket, uuid, struct, sys
+import socket, uuid, struct, sys, os
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
+import config
 
 def read_fully(sock, length):
 	result = b''
@@ -19,7 +22,7 @@ else:
 	LIST_PROTOCOL_ID = uuid.UUID("297d0df4-430c-bf61-640a-640897eaef57")
 	GG2_LOBBY_ID = uuid.UUID("1ccf16b1-436d-856f-504d-cc1af306aaa7")
 
-	with closing(socket.create_connection(("127.0.0.1", 29944))) as sock:
+	with closing(socket.create_connection(("127.0.0.1", config.NEWSTYLE_PORT))) as sock:
 		sock.sendall(LIST_PROTOCOL_ID.bytes + GG2_LOBBY_ID.bytes)
 
 		total_playercount = 0

--- a/protocols/common.py
+++ b/protocols/common.py
@@ -1,12 +1,10 @@
-import socket
 from twisted.internet.protocol import Protocol, ClientFactory
 from expirationset import expirationset
+import config
 
-RECENT_ENDPOINTS = expirationset(10)
+RECENT_ENDPOINTS = expirationset(config.REGISTRATION_THROTTLE_SECS)
 
-# Example IP
-BANNED_IP_STRINGS = {"1.2.3.4"}
-BANNED_IPS = {socket.inet_aton(x) for x in BANNED_IP_STRINGS}
+# Banned IP list is defined in config
 
 class SimpleTCPReachabilityCheck(Protocol):
     def __init__(self, server, host, port, serverList):

--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 import socket
 from expirationset import expirationset
+import config
 
 class GameServer:
     def __init__(self, server_id, lobby_id):
@@ -28,7 +29,7 @@ class GameServer:
         return retstr+">"
 
 class GameServerList:
-    def __init__(self, duration=70):
+    def __init__(self, duration=config.SERVER_EXPIRATION_SECS):
         self._expirationset = expirationset(duration, self._remove_callback)
         self._server_id_dict = {}
         self._endpoint_dict = {}

--- a/weblist.py
+++ b/weblist.py
@@ -1,20 +1,21 @@
 from twisted.web.resource import Resource
 from xml.sax.saxutils import escape, quoteattr
-import uuid, socket
+import socket
+import config
 
 pageTemplate = u"""<!doctype html>
 <html>
 <head>
     <title>Lobby status page</title>
-    <meta http-equiv="content-type" 
+    <meta http-equiv="content-type"
         content="text/html;charset=utf-8" />
-    <link rel="stylesheet" type="text/css" href="style.css" />  
+    <link rel="stylesheet" type="text/css" href="style.css" />
 </head>
 <body>
-    <img src="http://static.ganggarrison.com/Themes/GG2/images/smflogo.gif" alt="" id=smflogo><div id=head><img src="http://static.ganggarrison.com/GG2ForumLogo.png" alt="" id=logo></div>
-    %s
+    <img src="%s" alt="" id=smflogo><div id=head><img src="%s" alt="" id=logo></div>
+    %%s
 </body>
-</html>"""
+</html>""" % (config.LOGO_SMFL, config.LOGO_MAIN)
 
 tableTemplate = u"""
     <h2>Active servers in the %s</h2>
@@ -46,11 +47,6 @@ rowTemplate = u"""
                 </tr>
 """
 
-knownLobbies = {
-    uuid.UUID("1ccf16b1-436d-856f-504d-cc1af306aaa7") : u"Gang Garrison Lobby",
-    uuid.UUID("0e29560e-443a-93a3-e15e-7bd072df7506") : u"PyGG2 Testing Lobby",
-	uuid.UUID("4fd0319b-5868-4f24-8b77-568cbb18fde9") : u"Vanguard Lobby"
-}
 
 def htmlprep(utf8string):
     if isinstance(utf8string, bytes):
@@ -83,8 +79,8 @@ class LobbyStatusResource(Resource):
         return rowTemplate % (passworded, name, map, players, game, address)
         
     def _format_table(self, lobby):
-        if(lobby in knownLobbies):
-            lobbyname = escape(knownLobbies[lobby])
+        if lobby in config.KNOWN_LOBBIES:
+            lobbyname = escape(config.KNOWN_LOBBIES[lobby])
         else:
             lobbyname = u'unknown lobby "%s"' % lobby.hex
             


### PR DESCRIPTION
## Summary
- centralize lobby constants in `config.py`
- update server list, protocols, web UI and lobby startup to read from config
- make munin plugins load config even when symlinked
- document configuration options in README
- clean up banned IP access and fix munin plugin indentation

## Testing
- `pip install twisted requests`
- `python test_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_683f50e8724c8331bba028720f26a1b1