### PR TITLE
Add packaging and dependency metadata

### DIFF
--- a/README
+++ b/README
@@ -9,9 +9,13 @@ Start the lobby server:
 python lobby.py
 ```
 
-The server requires Python 3 and the Twisted framework. Install dependencies with:
+The server requires Python 3. Install dependencies using `requirements.txt`:
 ```bash
-pip install twisted requests
+pip install -r requirements.txt
+```
+You can also install the package in editable mode:
+```bash
+pip install -e .
 ```
 
 ### Configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Twisted
+requests

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='faucet-lobby',
+    version='0.1.0',
+    description='Game server lobby system for Gang Garrison 2 and generic games',
+    packages=find_packages(include=['protocols']),
+    py_modules=['config', 'expirationset', 'lobby', 'server', 'weblist'],
+    package_data={'': ['httpdocs/*']},
+    install_requires=['Twisted', 'requests'],
+    python_requires='>=3.7',
+)


### PR DESCRIPTION
## Summary
- add `requirements.txt` to document dependencies
- create `setup.py` packaging info
- mention installation steps in README

## Testing
- `python test_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_683f567c13b883318faa95dbdfa19da7