### PR TITLE
Refactor munin plugins, drop legacy imports

### DIFF
--- a/munin-plugins/gg2_common.py
+++ b/munin-plugins/gg2_common.py
@@ -1,0 +1,55 @@
+from contextlib import closing
+import socket
+import uuid
+import struct
+import os
+import sys
+
+# Ensure repository root is on path to import config
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
+import config
+
+
+def read_fully(sock, length):
+    """Read exactly *length* bytes from *sock*."""
+    result = b''
+    while len(result) < length:
+        chunk = sock.recv(length - len(result))
+        if not chunk:
+            raise ConnectionError("Socket closed unexpectedly")
+        result += chunk
+    return result
+
+
+def query_lobby_stats():
+    """Return (servercount, total_players, total_slots) from lobby."""
+    LIST_PROTOCOL_ID = uuid.UUID("297d0df4-430c-bf61-640a-640897eaef57")
+    GG2_LOBBY_ID = uuid.UUID("1ccf16b1-436d-856f-504d-cc1af306aaa7")
+
+    with closing(socket.create_connection(("127.0.0.1", config.NEWSTYLE_PORT))) as sock:
+        sock.sendall(LIST_PROTOCOL_ID.bytes + GG2_LOBBY_ID.bytes)
+
+        servercount = struct.unpack('>L', read_fully(sock, 4))[0]
+        total_playercount = 0
+        total_playerslots = 0
+        for _ in range(servercount):
+            serverlen = struct.unpack('>L', read_fully(sock, 4))[0]
+            serverblock = read_fully(sock, serverlen)
+            (
+                _protocol,
+                _ipv4_port,
+                _ipv4_ip,
+                _ipv6_port,
+                _ipv6_ip,
+                playerslots,
+                playercount,
+                _bots,
+                _flags,
+                _infolen,
+            ) = struct.unpack(
+                ">BH4sH16sHHHHH", serverblock[:35]
+            )
+            total_playercount += playercount
+            total_playerslots += playerslots
+
+    return servercount, total_playercount, total_playerslots

--- a/munin-plugins/gg2_players.py
+++ b/munin-plugins/gg2_players.py
@@ -1,42 +1,17 @@
 #!/usr/bin/python3
 
-from __future__ import with_statement
-from contextlib import closing
-import socket, uuid, struct, sys, os
+import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
-import config
+from gg2_common import query_lobby_stats
 
-def read_fully(sock, length):
-	result = b''
-	while(length-len(result) > 0):
-		result += sock.recv(length-len(result))
-	return result;
-		
 if(len(sys.argv) > 1 and sys.argv[1] == 'config'):
 	print("graph_title GG2 players and available slots")
 	print("graph_vlabel count")
 	print("players.label players")
 	print("slots.label slots")
 else:
-	LIST_PROTOCOL_ID = uuid.UUID("297d0df4-430c-bf61-640a-640897eaef57")
-	GG2_LOBBY_ID = uuid.UUID("1ccf16b1-436d-856f-504d-cc1af306aaa7")
+        _, total_playercount, total_playerslots = query_lobby_stats()
 
-	with closing(socket.create_connection(("127.0.0.1", config.NEWSTYLE_PORT))) as sock:
-		sock.sendall(LIST_PROTOCOL_ID.bytes + GG2_LOBBY_ID.bytes)
-
-		total_playercount = 0
-		total_playerslots = 0
-
-		servercount = struct.unpack('>L', read_fully(sock, 4))[0]
-		for i in range(servercount):
-			serverlen = struct.unpack('>L', read_fully(sock, 4))[0]
-			serverblock = read_fully(sock, serverlen)
-			(serverprotocol, ipv4_port, ipv4_ip, ipv6_port, ipv6_ip, playerslots, playercount, bots, flags, infolen) = struct.unpack(">BH4sH16sHHHHH", serverblock[:35])
-			
-			total_playercount += playercount
-			total_playerslots += playerslots
-			
-	print("players.value %s" % (total_playercount,))
-	print("slots.value %s" % (total_playerslots,))
+        print("players.value %s" % (total_playercount,))
+        print("slots.value %s" % (total_playerslots,))
 	

--- a/munin-plugins/gg2_servers.py
+++ b/munin-plugins/gg2_servers.py
@@ -1,40 +1,15 @@
 #!/usr/bin/python3
 
-from __future__ import with_statement
-from contextlib import closing
-import socket, uuid, struct, sys, os
+import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
-import config
+from gg2_common import query_lobby_stats
 
-def read_fully(sock, length):
-	result = b''
-	while(length-len(result) > 0):
-		result += sock.recv(length-len(result))
-	return result;
-		
 if(len(sys.argv) > 1 and sys.argv[1] == 'config'):
 	print("graph_title Registered GG2 servers")
 	print("graph_vlabel servers")
 	print("servers.label servers")
 
 else:
-	LIST_PROTOCOL_ID = uuid.UUID("297d0df4-430c-bf61-640a-640897eaef57")
-	GG2_LOBBY_ID = uuid.UUID("1ccf16b1-436d-856f-504d-cc1af306aaa7")
+        servercount, _, _ = query_lobby_stats()
 
-	with closing(socket.create_connection(("127.0.0.1", config.NEWSTYLE_PORT))) as sock:
-		sock.sendall(LIST_PROTOCOL_ID.bytes + GG2_LOBBY_ID.bytes)
-
-		total_playercount = 0
-		total_playerslots = 0
-
-		servercount = struct.unpack('>L', read_fully(sock, 4))[0]
-		for i in range(servercount):
-			serverlen = struct.unpack('>L', read_fully(sock, 4))[0]
-			serverblock = read_fully(sock, serverlen)
-			(serverprotocol, ipv4_port, ipv4_ip, ipv6_port, ipv6_ip, playerslots, playercount, bots, flags, infolen) = struct.unpack(">BH4sH16sHHHHH", serverblock[:35])
-			
-			total_playercount += playercount
-			total_playerslots += playerslots
-		
-	print("servers.value %s" % (servercount,))
+        print("servers.value %s" % (servercount,))


### PR DESCRIPTION
## Summary
- remove `from __future__ import with_statement`
- share duplicate lobby query logic between munin plugins

## Testing
- `pip install -r requirements.txt`
- `python test_integration.py` *(fails: Server registration and legacy protocol tests)*

------
https://chatgpt.com/codex/tasks/task_e_683f5b0be5c48331958f6ce14a882ab9